### PR TITLE
README: substitute travis-ci.org for travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![build](https://travis-ci.org/tolstoyevsky/hubot-vote-or-die.svg?branch=master)](https://travis-ci.org/tolstoyevsky/hubot-vote-or-die)
+[![build](https://travis-ci.com/tolstoyevsky/hubot-vote-or-die.svg?branch=master)](https://travis-ci.org/tolstoyevsky/hubot-vote-or-die)
 
 # hubot-vote-or-die
 


### PR DESCRIPTION
https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps